### PR TITLE
New `lsupport` definition to handle dimensional variables  

### DIFF
--- a/src/ModalAssociationRules.jl
+++ b/src/ModalAssociationRules.jl
@@ -103,7 +103,7 @@ export lleverage, gleverage
 
 include("mining-policies.jl")
 
-export islimited_length_itemset
+export islimited_length_itemset, isdimensionally_coherent_itemset
 export islimited_length_arule, isanchored_arule, isheterogeneous_arule
 
 include("algorithms/apriori.jl")
@@ -134,7 +134,7 @@ export patternbase, bounce!, projection
 export fpgrowth
 
 include("alphabet-proposal.jl")
-export motifsalphabet 
+export motifsalphabet
 
 # include("analysis.jl")
 # export plot_arule_analyses

--- a/src/ModalAssociationRules.jl
+++ b/src/ModalAssociationRules.jl
@@ -34,7 +34,7 @@ using StatsBase
 
 include("core.jl")
 
-export Item, formula
+export Item, formula, feature
 export Itemset
 
 export ARule

--- a/src/ModalAssociationRules.jl
+++ b/src/ModalAssociationRules.jl
@@ -96,6 +96,7 @@ include("meaningfulness-measures.jl")
 
 export @localmeasure, @globalmeasure, @linkmeas
 export lsupport, gsupport
+export dimensional_lsupport, dimensional_gsupport
 export lconfidence, gconfidence
 export llift, glift
 export lconviction, gconviction

--- a/src/algorithms/apriori.jl
+++ b/src/algorithms/apriori.jl
@@ -83,6 +83,10 @@ function apriori(
     candidates = Itemset{_itemtype}.(items(miner))
 
     while !isempty(candidates)
+        # certain candidates might automatically be removed because of filtering policies
+        filter!(candidate -> all(
+            _policy -> _policy(candidate), itemset_mining_policies(miner)), candidates)
+
         # get the frequent itemsets from the first candidates set
         frequents = [candidate
             for candidate in candidates
@@ -90,8 +94,7 @@ function apriori(
 
             # other than the meaningfulness measures,
             # all the itemset mining policies must be honored too.
-            if gmeas_algo(candidate, X, lthreshold, miner) >= gthreshold &&
-                all(__policy -> __policy(candidate), itemset_mining_policies(miner))
+            if gmeas_algo(candidate, X, lthreshold, miner) >= gthreshold
         ] |> Vector{Itemset{_itemtype}}
 
         push!(freqitems(miner), frequents...)

--- a/src/core.jl
+++ b/src/core.jl
@@ -42,6 +42,16 @@ function Base.show(io::IO, item::Item)
 end
 
 """
+    feature(item::Item)::VarFeature
+
+Utility to extract the feature wrapped within an [`Item`](@ref).
+
+See also [`Item`](@ref), `SoleData.VarFeature`, `SoleData.AbstractUnivariateFeature`.
+"""
+feature(item::Item) = return item |> formula |> SoleData.value |> SoleData.metacond |>
+    SoleData.feature
+
+"""
     const Itemset{I<:Item} = Vector{I}
 
 Vector collecting multiple [`Item`](@ref)s.

--- a/src/meaningfulness-measures.jl
+++ b/src/meaningfulness-measures.jl
@@ -222,6 +222,12 @@ _lsupport_logic = (itemset, X, ith_instance, miner) -> begin
         # for each world, compute on which worlds the model checking algorithm returns true
         check(formula(itemset), X, ith_instance, w)
 
+        # TODO
+        # when dealing with VariableDistance, we only want to check the itemset on those
+        # worlds that match the same shape with the specific variable.
+        # For example, if VariableDistance is wrapping a motif [1,2,3,4], I cannot check
+        # the variable on smaller nor bigger intervals.
+
         # NOTE: the `worldfilter` wrapped within `miner` is levereaged, if given
         for w in allworlds(miner; ith_instance=ith_instance)
     ])

--- a/src/meaningfulness-measures.jl
+++ b/src/meaningfulness-measures.jl
@@ -672,7 +672,7 @@ See also [`lchisquared`](@ref).
 # meaning that a global measure is associated to its corresponding local one.
 
 @linkmeas gsupport lsupport
-@linkmeas dimensional_gsupport, dimensional_lsupport
+@linkmeas dimensional_gsupport dimensional_lsupport
 
 @linkmeas gconfidence lconfidence
 

--- a/src/mining-policies.jl
+++ b/src/mining-policies.jl
@@ -35,7 +35,43 @@ function islimited_length_itemset(; maxlength::Union{Nothing,Integer}=nothing)::
     end
 end
 
+"""
+    function isdimensionally_coherent_itemset(;)::Function
+
+Closure returning a boolean function `F` with one argument `itemset::Itemset`.
+
+This is needed to ensure the Itemset is coherent with the dimensional definition of local
+support. All the propositions (or anchors) in an itemset must be `VariableDistance`s
+wrapping references of the same size.
+
+See also [`Itemset`](@ref), [`itemset_mining_policies`](@ref), `SoleData.VariableDistance`.
+"""
+function isdimensionally_coherent_itemset(;)::Function
+    # since we have no arguments, this closure seems useless;
+    # however, we stick to the same pattern.
+
+    return function _isdimensionally_coherent_itemset(itemset::Itemset)
+        # a generic Itemset contains Atoms and SyntaxTrees:
+        # the former are always propositions, while the latter are modal literals;
+        # we want to keep only the propositions, since they are the anchor of our itemset.
+        anchors = filter(item -> formula(item) isa Atom, itemset)
+
+        # in particular, all the anchors must be VariableDistances
+        _feature = anchor -> anchor |>
+            formula |> SoleData.value |> SoleData.metacond |> SoleData.feature
+
+        all(anchor -> _feature(anchor) isa VariableDistance, anchors)
+
+        # also, all their references must be of the same size (e.g., 5-length intervals)
+        _referencesize = vardistance -> _feature(vardistance) |> reference |> size
+        _anchorsize = _referencesize(anchors[1])
+        all(anchor -> _referencesize(anchor) == _anchorsize, anchors)
+    end
+end
+
+
 # policies related to association rule generation
+
 
 """
     function islimited_length_arule(;

--- a/src/mining-policies.jl
+++ b/src/mining-policies.jl
@@ -56,13 +56,8 @@ function isdimensionally_coherent_itemset(;)::Function
         # we want to keep only the propositions, since they are the anchor of our itemset.
         anchors = filter(item -> formula(item) isa Atom, itemset)
 
-        # in particular:
-        _feature = anchor -> anchor |>
-            formula |> SoleData.value |> SoleData.metacond |> SoleData.feature
-
-        # every Variable must not be a VariableDistance (e.g., VariableMin)
-        _anchortypes = Set([_feature(anchor) |> typeof for anchor in anchors])
-
+        # in particular, every Variable must not be a VariableDistance (e.g., VariableMin)
+        _anchortypes = Set([feature(anchor) |> typeof for anchor in anchors])
         if !any(_anchortype -> _anchortype <: VariableDistance, _anchortypes)
             return true
         end
@@ -73,7 +68,7 @@ function isdimensionally_coherent_itemset(;)::Function
         end
 
         # also, all their references must be of the same size (e.g., 5-length intervals)
-        _referencesize = vardistance -> _feature(vardistance) |> reference |> size
+        _referencesize = vardistance -> feature(vardistance) |> reference |> size
         _anchorsize = _referencesize(anchors[1])
 
         return all(anchor -> _referencesize(anchor) == _anchorsize, anchors)

--- a/src/utils/miner.jl
+++ b/src/utils/miner.jl
@@ -163,7 +163,8 @@ struct Miner{
         end
 
         # gsupport is crucial to mine association rule
-        if !(ModalAssociationRules.gsupport in first.(itemset_constrained_measures))
+        if !(gsupport in first.(itemset_constrained_measures) ||
+            dimensional_gsupport in first.(itemset_constrained_measures))
             throw(ArgumentError(
                 "Miner requires global support " *
                 "(gsupport) as meaningfulness measure in order to work properly. " *

--- a/test/matrix-profile.jl
+++ b/test/matrix-profile.jl
@@ -68,14 +68,14 @@ _rulemeasures = [(gconfidence, 0.2, 0.2)]
 logiset = scalarlogiset(X[1:30,:], [vd1, vd2, vm1, vm2])
 
 # build the miner, and mine!
-fpgrowth_miner = Miner(
+apriori_miner = Miner(
     logiset,
-    fpgrowth,
+    apriori,
     _items,
     _itemsetmeasures,
     _rulemeasures;
     itemset_mining_policies=[isdimensionally_coherent_itemset()]
 )
 
-@test_nowarn mine!(fpgrowth_miner)
-# @test freqitems(fpgrowth_miner) |> length == 0
+@test_nowarn mine!(apriori_miner)
+# @test freqitems(apriori_miner) |> length == 0

--- a/test/matrix-profile.jl
+++ b/test/matrix-profile.jl
@@ -4,7 +4,6 @@ using MatrixProfile
 using ModalAssociationRules
 using Plots
 using Plots.Measures
-using Statistics
 
 using SoleData
 

--- a/test/matrix-profile.jl
+++ b/test/matrix-profile.jl
@@ -58,7 +58,7 @@ _itemsetmeasures = [(gsupport, 0.1, 0.1)]
 _rulemeasures = [(gconfidence, 0.2, 0.2)]
 
 # build the logiset we will mine
-logiset = scalarlogiset(X[1:30,:], [vd1])
+logiset = scalarlogiset(X[1:30,:], [vd1, vd2])
 
 # build the miner, and mine!
 fpgrowth_miner = Miner(
@@ -70,5 +70,5 @@ fpgrowth_miner = Miner(
     itemset_mining_policies=[isdimensionally_coherent_itemset()]
 )
 
-mine!(fpgrowth_miner)
-@test freqitems(fpgrowth_miner) |> length == 1
+@test_nowarn mine!(fpgrowth_miner)
+# @test freqitems(fpgrowth_miner) |> length == 0

--- a/test/matrix-profile.jl
+++ b/test/matrix-profile.jl
@@ -61,7 +61,7 @@ q = Atom(ScalarCondition(vm2, <, 999.0))
 _items = Vector{Item}([proposition1, proposition2, p, q])
 
 # define meaningfulness measures
-_itemsetmeasures = [(gsupport, 0.001, 0.001)]
+_itemsetmeasures = [(dimensional_gsupport, 0.001, 0.001)]
 _rulemeasures = [(gconfidence, 0.2, 0.2)]
 
 # build the logiset we will mine

--- a/test/matrix-profile.jl
+++ b/test/matrix-profile.jl
@@ -24,7 +24,7 @@ th = 0  # how nearby in time two motifs are allowed to be
 
 _motifs = motifsalphabet(IHCC, windowlength, nmotifs; r=r, th=th)
 @test length(_motifs) == 3
-# plot(_motifs)
+# plot(_motifs) # uncomment to explore _motifs content
 
 # we isolated the only var_id 5 from the class "I have command",
 # thus we now have only one column/var_id;

--- a/test/matrix-profile.jl
+++ b/test/matrix-profile.jl
@@ -48,17 +48,24 @@ vd2 = VariableDistance(
 )
 
 # make proposition (we consider this as we entire alphabet, at the moment)
-proposition1 = Atom(ScalarCondition(vd1, <, 2.0))
-proposition2 = Atom(ScalarCondition(vd2, <, 2.0))
+proposition1 = Atom(ScalarCondition(vd1, <, 5.0))
+proposition2 = Atom(ScalarCondition(vd2, <, 5.0))
 
-_items = Vector{Item}([proposition1, proposition2])
+# those atoms will label possibly every world; they are agnostic of their size;
+# we introduce those to test whether `isdimensionally_coherent_itemset` filter policy
+# is working later.
+vm1, vm2 = VariableMin(1), VariableMin(2)
+p = Atom(ScalarCondition(vm1, <, 999.0))
+q = Atom(ScalarCondition(vm2, <, 999.0))
+
+_items = Vector{Item}([proposition1, proposition2, p, q])
 
 # define meaningfulness measures
-_itemsetmeasures = [(gsupport, 0.1, 0.1)]
+_itemsetmeasures = [(gsupport, 0.001, 0.001)]
 _rulemeasures = [(gconfidence, 0.2, 0.2)]
 
 # build the logiset we will mine
-logiset = scalarlogiset(X[1:30,:], [vd1, vd2])
+logiset = scalarlogiset(X[1:30,:], [vd1, vd2, vm1, vm2])
 
 # build the miner, and mine!
 fpgrowth_miner = Miner(


### PR DESCRIPTION
This pr wants to solve #50.

Motifs are already integrated into this package (see `motifsalphabet` in `src/alphabet-proposal.jl`), but when wrapping them into a variable, called `VariableDistance`, they are paired with a distance function.

Local support can be computed correctly for items wrapping those variables only by limiting its denominator to those worlds having the same size as the variable's motif. 

In the general scenario of computing local support for an `Itemset`, a new mining policy must be introduced to establish which itemsets are well-formed and which are nonsense. This policy is called `_isdimensionally_coherent_itemset`. See #50 for more details.

After introducing the policy, both `apriori` and `fpgrowth` should be adjusted.
Technically, local support is entirely computed by `_lsupport_logic`, called internally in `localmeasure` template (`src/meaningfulness-measures.jl`), but `fpgrowth` does some internal dirty tricks that must be probably be refactored.

At the moment of opening this pr, the policy is implemented.